### PR TITLE
Refined the Node.js Identity validation sample

### DIFF
--- a/docs/product/channels/live-chat/sdk/identity-validation.md
+++ b/docs/product/channels/live-chat/sdk/identity-validation.md
@@ -31,9 +31,7 @@ const crypto = require('crypto');
 const key = 'webwidget.hmac_token';
 const message = 'identifier';
 
-const hash = crypto.createHmac('sha256', key).update(message);
-
-hash.digest('hex');
+const hash = crypto.createHmac('sha256', key).update(message).digest('hex');
 ```
 
 ### Ruby


### PR DESCRIPTION
Having the hash.digest('hex') on another line without an assignment seemed confusing.