### PR TITLE
One-liner the rails console

### DIFF
--- a/docs/self-hosted/deployment/docker.md
+++ b/docs/self-hosted/deployment/docker.md
@@ -155,8 +155,6 @@ Update the images using the latest image from chatwoot. Run the `rails db:chatwo
 ```
 # Find the name of the rails server container
 docker ps
-# access the shell inside the container. replace name if you are using a different name
-docker exec -it $(docker ps --filter name=root_rails_1 -q) /bin/sh
-# start rails console
-RAILS_ENV=production bundle exec rails c
+# use the shell inside the container to start rails console. replace name if you are using a different name
+docker exec -it $(docker ps --filter name=root_rails_1 -q) /bin/sh -c 'RAILS_ENV=production bundle exec rails c'
 ```

--- a/docs/self-hosted/deployment/docker.md
+++ b/docs/self-hosted/deployment/docker.md
@@ -153,8 +153,6 @@ Update the images using the latest image from chatwoot. Run the `rails db:chatwo
 ## Running Rails Console
 
 ```
-# Find the name of the rails server container
-docker ps
-# use the shell inside the container to start rails console. replace name if you are using a different name
-docker exec -it $(docker ps --filter name=root_rails_1 -q) /bin/sh -c 'RAILS_ENV=production bundle exec rails c'
+# Run this from within the working directory you `docker-compose up -d` in the context of
+docker exec -it $(basename $(pwd))_rails_1 sh -c 'RAILS_ENV=production bundle exec rails c'
 ```

--- a/docs/self-hosted/deployment/docker.md
+++ b/docs/self-hosted/deployment/docker.md
@@ -153,6 +153,5 @@ Update the images using the latest image from chatwoot. Run the `rails db:chatwo
 ## Running Rails Console
 
 ```
-# Run this from within the working directory you `docker-compose up -d` in the context of
 docker exec -it $(basename $(pwd))_rails_1 sh -c 'RAILS_ENV=production bundle exec rails c'
 ```


### PR DESCRIPTION
What do you think about this shortening of the rails console?
Once you exit, you'd be placed back outside the container.
Coupling this with an alias, I find can make things a little more natural for me.

* Does not specify path to shell, assumes it's executable is in the `PATH`
* Uses default `docker-compose up` container name, using `basepath` of `pwd` as a prefix, with predictable suffix.
* Continues to use `bundle exec`, so users can work-out nearly any bundler installed utility.