### PR TITLE
Update config for using minio as active storage

### DIFF
--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -60,15 +60,17 @@ AZURE_STORAGE_CONTAINER=
 
 ### Using Amazon S3 Compatible Service
 
-Use s3 compatible service such as [DigitalOcean Spaces](https://www.digitalocean.com/docs/spaces/resources/s3-sdk-examples/#configure-a-client), Minio.
+To use an s3 compatible service such as [DigitalOcean Spaces](https://www.digitalocean.com/docs/spaces/resources/s3-sdk-examples/#configure-a-client), Minio etc..
 
 Configure the following env variables.
 
 ```bash
-ACTIVE_STORAGE_SERVICE='s3_compatible'
+ACTIVE_STORAGE_SERVICE=s3_compatible
 STORAGE_BUCKET_NAME=
 STORAGE_ACCESS_KEY_ID=
 STORAGE_SECRET_ACCESS_KEY=
 STORAGE_REGION=nyc3
 STORAGE_ENDPOINT=https://nyc3.digitaloceanspaces.com
+#set force_path_style to true if using minio
+#STORAGE_FORCE_PATH_STYLE=true
 ```


### PR DESCRIPTION
- quotes around s3_compatible was causing rails to not pickup `minio`
- `minio` was failing to start when STORAGE_FORCE_PATH_STYLE was not set to true.
    ref: --> https://github.com/chatwoot/chatwoot/pull/1134