### PR TITLE
remove unnecessary quotes in storage configuration

### DIFF
--- a/docs/self-hosted/configuration/environment-variables.md
+++ b/docs/self-hosted/configuration/environment-variables.md
@@ -122,7 +122,7 @@ Chatwoot uses [active storage](https://edgeguides.rubyonrails.org/active_storage
 But you can change it to use any of the cloud providers like amazon s3, microsoft azure and google gcs etc. Refer [configuring cloud storage](/docs/self-hosted/deployment/storage/supported-providers) for additional environment variables required.
 
 ```bash
-ACTIVE_STORAGE_SERVICE='local'
+ACTIVE_STORAGE_SERVICE=local
 ```
 
 ### Configure Redis


### PR DESCRIPTION
Current documentation says: 
`ACTIVE_STORAGE_SERVICE='local'`

but it fails the docker image build as right value is 
`ACTIVE_STORAGE_SERVICE=local`