### PR TITLE
Fixes: Mention the env variables SMTP_TLS and SMTP_SSL in docs (#3396)

### DIFF
--- a/docs/self-hosted/configuration/environment-variables.md
+++ b/docs/self-hosted/configuration/environment-variables.md
@@ -53,6 +53,8 @@ and based on your SMTP server the following variables
 SMTP_ADDRESS=
 SMTP_USERNAME=
 SMTP_PASSWORD=
+SMTP_TLS=
+SMTP_SSL=
 ```
 
 #### Amazon SES


### PR DESCRIPTION
Fixes [#3396](https://github.com/chatwoot/chatwoot/issues/3396)

## Tasks
- [x] Mention the environment variables SMTP_TLS and SMTP_SSL in .env.example
- [x] Mention the same in documentation 