### PR TITLE
Chore: Facebook's updated policy to page's insights

### DIFF
--- a/docs/self-hosted/configuration/features/integrations/facebook-channel-setup.md
+++ b/docs/self-hosted/configuration/features/integrations/facebook-channel-setup.md
@@ -62,7 +62,11 @@ Business Asset User Profile Access
 pages_show_list
 pages_manage_metadata
 ```
-
+### NOTE
+If your facebook app's version is more than 7.0 then you will need extra permission according to facebook's updated policy. Make sure you get permission for.
+```
+pages_read_engagement
+```
 
 ### Developing or Testing Facebook Integration in your machine
 

--- a/docs/self-hosted/configuration/features/integrations/instagram-channel-setup.md
+++ b/docs/self-hosted/configuration/features/integrations/instagram-channel-setup.md
@@ -75,7 +75,11 @@ pages_show_list
 pages_manage_metadata
 pages_messaging
 ```
-
+### NOTE
+If your facebook app's version is more than 7.0 then you will need extra permission according to facebook's updated policy. Make sure you get permission for.
+```
+pages_read_engagement
+```
 
 ### Developing or Testing Facebook Integration in your machine
 


### PR DESCRIPTION
#165 According to facebook's updated policy they have deprecated manage_page permission, so all the new apps will have to have permission for `pages_read_engagement` to read the connected Instagram account.

https://developers.facebook.com/docs/graph-api/changelog/version7.0/