### PR TITLE
chore: revert references to GlobalConfig

### DIFF
--- a/docs/self-hosted/configuration/environment-variables.md
+++ b/docs/self-hosted/configuration/environment-variables.md
@@ -5,7 +5,7 @@ title: "Environment Variables"
 
 ### Configure frontend URL (Domain)
 
-Provide the your chatwoot domain as frontend url.
+Provide your chatwoot domain as frontend url.
 
 ```bash
 FRONTEND_URL='https://your-chatwoot-domain.tld'

--- a/docs/self-hosted/configuration/environment-variables.md
+++ b/docs/self-hosted/configuration/environment-variables.md
@@ -3,6 +3,14 @@ path: "/docs/environment-variables"
 title: "Environment Variables"
 ---
 
+### Configure frontend URL (Domain)
+
+Provide the your chatwoot domain as frontend url.
+
+```bash
+FRONTEND_URL='https://your-chatwoot-domain.tld'
+```
+
 
 ### Database configuration
 
@@ -101,14 +109,6 @@ SMTP_ENABLE_STARTTLS_AUTO=true
 SMTP_PORT=587
 SMTP_USERNAME=<Your SMTP username displayed under Settings -> SMTP & API info>
 SMTP_PASSWORD=<Any valid API key, create an API key under Settings -> SMTP & API Info>
-```
-
-### Configure frontend URL
-
-Provide the following value as frontend url
-
-```bash
-FRONTEND_URL='http://localhost:3000'
 ```
 
 ### Configure default language
@@ -215,5 +215,3 @@ By default, Chatwoot will not allow users to create an account[multi-tenancy] fr
 ```bash
 ENABLE_ACCOUNT_SIGNUP=true
 ```
-
-> **NOTE**: Right now, Chatwoot is trying to simplify this setup and have this configuration be done from the UI. If you are using a Chatwoot version latest than v1.22.1, set the `ENABLE_ACCOUNT_SIGNUP` variable in Chatwoot super admin panel under InstallationConfig. The url to access super_admin panel is `<your-chatwoot-domain.com>/super_admin`. If you were using an older version of Chatwoot, your existing environment variable setting would be automatically migrated to the InstallationConfig setting.

--- a/docs/self-hosted/configuration/features/integrations/facebook-channel-setup.md
+++ b/docs/self-hosted/configuration/features/integrations/facebook-channel-setup.md
@@ -24,8 +24,6 @@ FB_APP_SECRET=
 FB_APP_ID=
 ```
 
-> **NOTE**: Right now, Chatwoot is trying to simplify this setup and have this configuration be done from the UI. If you are using a Chatwoot version latest than v1.22.1, set the above FB credentials in Chatwoot super admin panel under InstallationConfig. The url to access super_admin panel is `<your-chatwoot-domain.com>/super_admin`. If you were using an older version of Chatwoot, your existing environment variable setting would be automatically migrated to the InstallationConfig setting.
-
 ### Configure the Facebook App
 
 1. In the app settings, add your `Chatwoot installation domain` as your app domain.
@@ -100,4 +98,3 @@ Restart the Chatwoot local server. Your Chatwoot setup will be ready to receive 
 1. After finishing the set-up above, [create a Facebook inbox](/docs/product/channels/facebook) after logging in to your Chatwoot Installation.
 2. Send a message to your page from Facebook.
 3. Wait and confirm incoming requests to `/bot` endpoint in your ngrok screen.
-


### PR DESCRIPTION

Description
----
Priority to GlobalConfig changes are reverted and for the time being env vars will take precedence if set. 

- chore: revert references to GlobalConfig


ref: https://github.com/chatwoot/chatwoot/pull/3702