### PR TITLE
Fixed Doc Error in Specifying Agent ID Data Type (WebHook-events)

### DIFF
--- a/docs/product/others/webhook-events.md
+++ b/docs/product/others/webhook-events.md
@@ -22,7 +22,7 @@ Chatwoot Publishes Various events to Webhook Endpoints if any of the following a
   "content_attributes": {} // This will an object, different values are defined below
   "source_id": "", // This would the external id if the inbox is a Twitter or Facebook integration.
   "sender": { // This would provide the details of the agent who sent this message
-    "id": "1",
+    "id": 1,
     "name": "Agent",
     "email": "agent@example.com"
   },


### PR DESCRIPTION
The ID of Agents Specified in Webhook events example is specified as a String Type but actually it's of Type Int