### PR TITLE
doc: update linux install script domain

### DIFF
--- a/docs/self-hosted/configuration/features/integrations/slack-integration-setup.md
+++ b/docs/self-hosted/configuration/features/integrations/slack-integration-setup.md
@@ -47,7 +47,7 @@ Restart the Chatwoot server.
 
 ## Connect Chatwoot with your Slack workspace
 
-Follow this [guide](docs/product/features/slack) to complete the Slack integration.
+Follow this [guide](/docs/product/features/slack) to complete the Slack integration.
 
 ## Testing your setup
 

--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -19,14 +19,14 @@ This guide will help you to install **Chatwoot** on **Ubuntu 20.04 LTS / 20.10**
 1. Create a **setup.sh** file and copy the content from the above link or use the following commands.
 
 ```bash
-wget https://raw.githubusercontent.com/chatwoot/chatwoot/master/deployment/setup_20.04.sh -O setup.sh
-chmod 755 setup.sh
+wget https://get.chatwoot.app/linux/install.sh
+chmod +x install.sh
 ```
 
 2. Execute the script, and it will take care of the initial **Chatwoot** setup.
 
 ```bash
-./setup.sh master
+./install.sh master
 ```
 
 3. **Chatwoot** Installation will now be accessible at `http://{your_ip_address}:3000` or if you opted


### PR DESCRIPTION
- serve the Linux installation script from memorable domain
- https://get.chatwoot.app/linux/install.sh

Fixes https://github.com/chatwoot/product/issues/379