### PR TITLE
Fixing examples in docs misrepresented as links

### DIFF
--- a/docs/product/channels/sms/twilio.md
+++ b/docs/product/channels/sms/twilio.md
@@ -62,7 +62,7 @@ For such cases you can follow the given steps.
 
 **REQUEST METHOD** : POST
 
-**REQUEST URL**: https://app.chatwoot.com/twilio/callback
+**REQUEST URL**: `https://app.chatwoot.com/twilio/callback`
 
 **CONTENT TYPE**: Application/JSON
 

--- a/docs/product/others/interactive-messages.md
+++ b/docs/product/others/interactive-messages.md
@@ -4,7 +4,7 @@ title: "Interactive Messages"
 
 Chatwoot lets you create interactive message types like cards and forms in side your Chatwoot Web Widget using the APIs.
 
-You can create these messages using the [New Message API.](https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation).
+You can create these messages using the [New Message API](https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation).
 
 ![interactive_messages](./images/interactive_messages.png)
 

--- a/docs/product/others/interactive-messages.md
+++ b/docs/product/others/interactive-messages.md
@@ -4,7 +4,7 @@ title: "Interactive Messages"
 
 Chatwoot lets you create interactive message types like cards and forms in side your Chatwoot Web Widget using the APIs.
 
-You can create these messages using the[New Message API.](https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation).
+You can create these messages using the [New Message API.](https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation).
 
 ![interactive_messages](./images/interactive_messages.png)
 

--- a/docs/product/others/interactive-messages.md
+++ b/docs/product/others/interactive-messages.md
@@ -4,7 +4,7 @@ title: "Interactive Messages"
 
 Chatwoot lets you create interactive message types like cards and forms in side your Chatwoot Web Widget using the APIs.
 
-You can create these messages using the New Message API.
+You can create these messages using the[New Message API.](https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation).
 
 ![interactive_messages](./images/interactive_messages.png)
 

--- a/docs/product/others/interactive-messages.md
+++ b/docs/product/others/interactive-messages.md
@@ -4,7 +4,7 @@ title: "Interactive Messages"
 
 Chatwoot lets you create interactive message types like cards and forms in side your Chatwoot Web Widget using the APIs.
 
-You can create these messages using the [New Message API.](https://www.chatwoot.com/developers/api/develop/#operation/create-a-new-message-in-a-conversation)
+You can create these messages using the New Message API.
 
 ![interactive_messages](./images/interactive_messages.png)
 

--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -28,7 +28,7 @@ chmod +x install.sh
 ```
 
 3. **Chatwoot** Installation will now be accessible at `http://{your_ip_address}:3000` or if you opted
-   for domain setup, it will be at https://chatwoot.mydomain.com.
+   for domain setup, it will be at `https://chatwoot.mydomain.com`.
 
 > **Note** This will also install the Chatwoot CLI(`cwctl`) starting with Chatwoot v2.7.0. Use `cwctl --help` to learn more.
 


### PR DESCRIPTION
Reason: These appeared as dead links in the SEO audit.