### PR TITLE
chore: add note for upgrades if version less than 2.7

### DIFF
--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -71,6 +71,8 @@ Whenever a new version of Chatwoot is released, use the following steps to upgra
 
 To install `cwctl`, refer [this](#install-or-upgrade-chatwoot-cli) section below.
 
+> **Note** If you are on an older version of Chatwoot(<2.7), follow the manual upgrade steps below if you face errors with `cwctl`.
+
 Run the following steps on your VM. Make changes based on your OS if you are on a non-Ubuntu system.
 
 ```bash

--- a/docs/self-hosted/deployment/upgrade.md
+++ b/docs/self-hosted/deployment/upgrade.md
@@ -9,6 +9,9 @@ Whenever a new version of Chatwoot is released, use the following steps to upgra
 
 > **Note** To install `cwctl`, refer [this](#install-or-upgrade-chatwoot-cli) section below.
 
+> **Note** If you are on an older version of Chatwoot(<2.7), follow the [manual upgrade steps](/docs/self-hosted/deployment/linux-vm#upgrading-to-a-newer-version-of-chatwoot) if you face errors with `cwctl`.
+
+
 ```
 cwctl --upgrade
 ```


### PR DESCRIPTION
Fix https://github.com/chatwoot/docs/issues/332

cwctl --upgrade have issues with versions less than 2.7. Add a note to use manual upgrade steps if upgrading from old versions of Chatwoot.