### PR TITLE
Update new message api documentation URL

### DIFF
--- a/docs/product/channels/api/send-messages.md
+++ b/docs/product/channels/api/send-messages.md
@@ -77,7 +77,7 @@ You will receive a conversation id which can be used to create a message.
 
 #### 3. Create a new message
 
-API documentation: (https://www.chatwoot.com/developers/api/develop/#operation/create-a-new-message-in-a-conversation)
+API documentation: (https://www.chatwoot.com/developers/api/#operation/create-a-new-message-in-a-conversation)
 
 There are 2 types of messages.
 


### PR DESCRIPTION
The API documentation URL for creating a new message points to an incorrect URL. Which is fixed in this PR. 

https://www.chatwoot.com/docs/product/channels/api/send-messages/

<img width="963" alt="Screenshot 2022-10-03 at 5 29 59 PM" src="https://user-images.githubusercontent.com/97214545/193571773-9b914cbd-1b34-4673-ad0a-8c30871c359f.png">
