### PR TITLE
Update android app setup instructions

### DIFF
--- a/docs/contributing-guide/mobile-app/setup-guide.md
+++ b/docs/contributing-guide/mobile-app/setup-guide.md
@@ -80,7 +80,7 @@ Open `Chatwoot.xcworkspace` file under `ios` folder. Choose your target device a
 
 ### Android
 
-- Create `gradle.properties` file with following contents under `android/app` folder
+- Create `gradle.properties` file with following contents under `android/` folder
 
 ```
 android.useAndroidX=true


### PR DESCRIPTION
In the docs location for gradle.properties for the Android app setup is mentioned incorrectly.
This file needs to be created inside root android folder and not inside android/app folder