### PR TITLE
doc: update gcs-bucket.md

### DIFF
--- a/docs/self-hosted/deployment/storage/gcs-bucket.md
+++ b/docs/self-hosted/deployment/storage/gcs-bucket.md
@@ -74,7 +74,9 @@ A sample credential file is of the following format.
 }
 ```
 
-When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line
+When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line. 
 ```
 GCS_CREDENTIALS={"type": "service_account","project_id": "","private_key_id": "","private_key": "","client_email": "","client_id": "","auth_uri": "","token_uri": "","auth_provider_x509_cert_url": "","client_x509_cert_url": ""}
 ```
+
+**Note**: If you are running Chatwoot v2.17+, make sure to wrap `GCS_CREDENTIALS` in single quotes.

--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -31,7 +31,7 @@ GCS_CREDENTIALS=
 GCS_BUCKET=
 ```
 
-The value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys. When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line.
+The value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys.
 
 ```bash
 {
@@ -46,6 +46,11 @@ The value of the `GCS_CREDENTIALS` should be a json formatted string containing 
   "auth_provider_x509_cert_url" : "",
   "client_x509_cert_url" : ""
 }
+```
+When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line.
+
+```
+GCS_CREDENTIALS=`{"type": "service_account","project_id": "","private_key_id": "","private_key": "","client_email": "","client_id": "","auth_uri": "","token_uri": "","auth_provider_x509_cert_url": "","client_x509_cert_url": ""}`
 ```
 
 ### Using Microsoft Azure

--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -31,7 +31,7 @@ GCS_CREDENTIALS=
 GCS_BUCKET=
 ```
 
-The value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys. When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line
+The value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys. When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line.
 
 ```bash
 {

--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -20,7 +20,7 @@ AWS_REGION=
 
 ### Using Google GCS
 
-**Note**: Starting with version 2.17+, wrap the GCS_CREDENTIALS environment variable in single quotes.
+**Note**: Starting with version 2.17+, wrap the `GCS_CREDENTIALS` environment variable in single quotes.
 
 Configure the following env variables.
 

--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -50,7 +50,7 @@ The value of the `GCS_CREDENTIALS` should be a json formatted string containing 
 When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line.
 
 ```
-GCS_CREDENTIALS=`{"type": "service_account","project_id": "","private_key_id": "","private_key": "","client_email": "","client_id": "","auth_uri": "","token_uri": "","auth_provider_x509_cert_url": "","client_x509_cert_url": ""}`
+GCS_CREDENTIALS={"type": "service_account","project_id": "","private_key_id": "","private_key": "","client_email": "","client_id": "","auth_uri": "","token_uri": "","auth_provider_x509_cert_url": "","client_x509_cert_url": ""}
 ```
 
 ### Using Microsoft Azure

--- a/docs/self-hosted/deployment/storage/supported-providers.md
+++ b/docs/self-hosted/deployment/storage/supported-providers.md
@@ -20,6 +20,8 @@ AWS_REGION=
 
 ### Using Google GCS
 
+**Note**: Starting with version 2.17+, wrap the GCS_CREDENTIALS environment variable in single quotes.
+
 Configure the following env variables.
 
 ```bash
@@ -29,7 +31,7 @@ GCS_CREDENTIALS=
 GCS_BUCKET=
 ```
 
-the value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys
+The value of the `GCS_CREDENTIALS` should be a json formatted string containing the following keys. When pasting the credentials to the ENV file, make sure to remove the new lines and paste it into a single line
 
 ```bash
 {


### PR DESCRIPTION
For GCS setup in Chatwoot, the `GCS_CREDENTIALS` environment variable needs to be wrapped in single quotes starting with version 2.17.