### PR TITLE
Fix an incorrect env var in conversation-continuity.md

### DIFF
--- a/docs/self-hosted/configuration/features/email-channel/conversation-continuity.md
+++ b/docs/self-hosted/configuration/features/email-channel/conversation-continuity.md
@@ -35,7 +35,7 @@ This configures the ingress service for the app. Now we have to set the password
 # Set this if you are using Sendgrid, Exim, Postfix, Qmail or Postmark
 RAILS_INBOUND_EMAIL_PASSWORD=
 # Set this if you are Mailgun
-MAILGUN_INGRESS_API_KEY=
+MAILGUN_INGRESS_SIGNING_KEY=
 # Set this if you are Mandrill
 MANDRILL_INGRESS_API_KEY=
 ```


### PR DESCRIPTION
Changes the MANDRILL_INGRESS_API_KEY env var to MAILGUN_INGRESS_SIGNING_KEY, which is the correct one according to https://github.com/chatwoot/chatwoot/blob/develop/.env.example#L95