### PR TITLE
feat: add gh action to check for broken links in chatwoot website

### DIFF
--- a/.github/workflows/broken-links-check.yml
+++ b/.github/workflows/broken-links-check.yml
@@ -1,0 +1,25 @@
+on:
+  schedule:
+    - cron: 0 10 1 * *
+  repository_dispatch:
+    types: [check-link]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+name: Broken Link Check
+jobs:
+  check:
+    name: Broken Link Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Broken Link Check
+        uses: technote-space/broken-link-checker-action@gh-actions
+        with:
+          TARGET: "https://www.chatwoot.com"
+          GITHUB_TOKEN: ${{secrets.ACCESS_TOKEN}}
+          
+
+


### PR DESCRIPTION
Context
----
We are having missing/broken/404 links in the website/docs due to the nature of the internet.  😅 

Changelog
----
- Add a gh action which will run monthly to scan for broken links
- This will create issues for broken links

