### PR TITLE
fix(docs): default helm chart value for signup

### DIFF
--- a/docs/self-hosted/deployment/helm-charts.md
+++ b/docs/self-hosted/deployment/helm-charts.md
@@ -68,7 +68,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `env.ACTIVE_STORAGE_SERVICE`         | Storage service. `local` for disk. `amazon` for s3.                 | `"local"`                                                  |
 | `env.ASSET_CDN_HOST`                 | Set if CDN is used for asset delivery.                              | `""`                                                       |
 | `env.INSTALLATION_ENV`               | Sets chatwoot installation method.                                  | `"helm"`                                                   |
-| `env.ENABLE_ACCOUNT_SIGNUP`          | `true` : default option, allows sign ups, `false` : disables all the end points related to sign ups, `api_only`: disables the UI for signup but you can create sign ups via the account apis.  | `"false"`                                                  |
+| `env.ENABLE_ACCOUNT_SIGNUP`          | `true` : allows sign ups, `false` : (default option) disables all the end points related to sign ups, `api_only`: disables the UI for signup but you can create sign ups via the account apis.  | `"false"`                                                  |
 | `env.FORCE_SSL`                      | Force all access to the app over SSL, default is set to false.                  | `"false"`                                                  |
 | `env.FRONTEND_URL`                   | Replace with the URL you are planning to use for your app.                      | `"http://0.0.0.0:3000/"`                                   |
 | `env.IOS_APP_ID`                     | Change this variable only if you are using a custom build for mobile app.       | `"6C953F3RX2.com.chatwoot.app"`                            |


### PR DESCRIPTION
fixes the chart documentation to reflect that the default value for ENABLE_ACCOUNT_SIGNUP is false