### PR TITLE
doc: update cwctl target to 24.04 LTS

### DIFF
--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -5,7 +5,7 @@ title: "Production deployment guide for Linux VM"
 
 ## Deploying to Linux VM
 
-This guide will help you to install **Chatwoot** on **Ubuntu 20.04 LTS, 22.04 or 24.04** or . We have prepared a deployment script for you to run. Refer to the script and feel free to make changes accordingly to the operating system if you are on a non-Ubuntu system.
+This guide will help you install **Chatwoot** on **Ubuntu 24.04 LTS. We have prepared a deployment script for you to run. Refer to the script and feel free to make changes accordingly to the operating system if you are on a non-Ubuntu system.
 
 <iframe width="100%" height="443" src="https://www.youtube.com/embed/vu_61D1VFAk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 


### PR DESCRIPTION
- Cwctl targetting chatwoot v4 is having some issues on Ubuntu 22.04
- This PR updates the recommended OS for new installations to the latest  LTS 24.04