### PR TITLE
doc: fix nginx config in docker guide

### DIFF
--- a/docs/self-hosted/deployment/docker.md
+++ b/docs/self-hosted/deployment/docker.md
@@ -106,7 +106,6 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     proxy_http_version 1.1;
-    proxy_set_header Connection “”;
     proxy_buffering off;
 
     client_max_body_size 0;


### PR DESCRIPTION
The proxy_set_header Connection directive was defined twice, causing a conflict. Remove the duplicate. 

Fixes https://linear.app/chatwoot/issue/CW-3958/invalid-nginx-config