### PR TITLE
doc: update linux manual upgrade guide

### DIFF
--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -86,12 +86,12 @@ cd chatwoot
 git checkout master && git pull
 
 # Ensure the ruby version is upto date
-rvm install "ruby-3.2.2"
-rvm use 3.2.2 --default
+rvm install "ruby-3.3.3"
+rvm use 3.3.3 --default
 
 # Update dependencies
 bundle
-yarn
+pnpm
 
 # Recompile the assets
 rake assets:precompile RAILS_ENV=production

--- a/docs/self-hosted/deployment/linux-vm.md
+++ b/docs/self-hosted/deployment/linux-vm.md
@@ -91,7 +91,7 @@ rvm use 3.3.3 --default
 
 # Update dependencies
 bundle
-pnpm
+pnpm i
 
 # Recompile the assets
 rake assets:precompile RAILS_ENV=production


### PR DESCRIPTION
- update the Linux manual upgrade instructions to be compatible with the latest Chatwoot requirements