### PR TITLE
docs: Update file size limits and formats for messaging channels

### DIFF
--- a/self-hosted/supported-features.mdx
+++ b/self-hosted/supported-features.mdx
@@ -103,13 +103,14 @@ The default maximum file size limit is 40MB.
 | Channel         | Audio                     | Image                | Video                          | Document      |
 | --------------- | ------------------------- | -------------------- | ------------------------------ | ------------- |
 | Website         | All                       | All                  | All                            | All           |
-| Instagram       | aac, m4a, wav, mp4 (25mb) | png, jpeg, gif (8mb) | mp4, ogg, avi, mov, web (25mb) | Not supported |
-| Facebook        | All                       | All                  | All                            | All           |
-| WhatsApp Cloud  | All                       | All                  | All                            | All           |
+| Instagram       | aac, m4a, wav, mp4 (25mb) | png, jpeg, gif (16mb)| mp4, ogg, avi, mov, web (25mb) | Not supported |
+| Facebook        | aac, m4a, wav, mp4 (25mb) | png, jpeg, gif (8mb) | mp4, ogg, avi, mov, webm (25mb)| pdf, xls(x), doc(x), ppt(x) (25mb) |
+| WhatsApp Cloud  | aac, amr, mp3, m4a, ogg  (16mb) | png, jpeg (5mb)| 3gp, mp4 (16mb)                | pdf, xls(x), doc(x), ppt(x) (100mb) |
 | WhatsApp Twilio | mpeg, opus, ogg, amr(5mb) | png, jpeg (5mb)      | mp4 (5mb)                      | pdf (5mb)     |
+| Twilio SMS      | All(5mb) | png, jpeg (5mb)| All (5mb)            | All (5mb)                      | All(5mb)     |
 | Email           | All                       | All                  | All                            | All           |
 | Telegram        | All                       | All                  | All                            | All           |
-| Line            | Not supported             | png, jpeg            | mp4                            | Not supported |
+| Line            | Not supported             | png, jpeg (10mg)     | mp4 (40mb)                     | Not supported |
 | API             | All                       | All                  | All                            | All           |
 
 <Note>


### PR DESCRIPTION
**Before**
<img width="767" height="605" alt="image" src="https://github.com/user-attachments/assets/bd850b04-2733-4984-a67c-e8c97e3edff2" />

**After**
<img width="767" height="698" alt="image" src="https://github.com/user-attachments/assets/1066b078-93d8-4402-bb43-5bb513105eab" />
