### PR TITLE
Update docker.mdx

### DIFF
--- a/self-hosted/deployment/docker.mdx
+++ b/self-hosted/deployment/docker.mdx
@@ -50,7 +50,7 @@ Tweak the `.env` and `docker-compose.yaml` according to your preferences. Refer 
 ```bash
 # update redis and postgres passwords
 nano .env
-# update docker-compose.yaml same postgres pass
+# update docker-compose.yaml same postgres pass and database name
 nano docker-compose.yaml
 ```
 


### PR DESCRIPTION
Add advise for add the same database name of the docker-compose.yml to the .env file to prevent the deploy error.

By default on the .env file the POSTGRES_DATABASE variable is commented what causes the deploy command "docker compose run --rm rails bundle exec rails db:chatwoot_prepare" to create a default database with the name "chatwoot_production" which is different from the one in the compose file "chatwoot"

"We could not find your database: chatwoot_production. Available database configurations can be found in config/database.yml."