### PR TITLE
docs: clarify specific-version upgrade guidance

### DIFF
--- a/self-hosted/deployment/chatwoot-ctl.mdx
+++ b/self-hosted/deployment/chatwoot-ctl.mdx
@@ -53,6 +53,18 @@ sudo cwctl --upgrade
 This will upgrade your Chatwoot instance to the latest stable release. If you are running a custom branch in production do not use this to upgrade.
 </Note>
 
+To upgrade to a specific Chatwoot version, use `-U`/`--Upgrade` with a git ref.
+
+```bash
+sudo cwctl -U <VERSION>
+# example
+sudo cwctl -U v4.3.0
+```
+
+<Note>
+`-u`/`--upgrade` upgrades to latest stable (`master`), while `-U`/`--Upgrade` upgrades to a specific git ref and is currently experimental. Upgrades can fail when your Chatwoot repo has local code changes, so keep production changes clean and take backups before upgrading. Under the hood, `-U` performs a `git checkout <VERSION>` followed by `git pull`.
+</Note>
+
 ### Setup Nginx with SSL after installation
 
 To set up Nginx with SSL after initial setup(if you answered `no` to webserver/SSL setup during the first install)
@@ -97,4 +109,4 @@ To check the version of Chatwoot CTL,
 
 ```bash
 sudo cwctl --version
-``` 
+```

--- a/self-hosted/deployment/chatwoot-ctl.mdx
+++ b/self-hosted/deployment/chatwoot-ctl.mdx
@@ -53,17 +53,19 @@ sudo cwctl --upgrade
 This will upgrade your Chatwoot instance to the latest stable release. If you are running a custom branch in production do not use this to upgrade.
 </Note>
 
-To upgrade to a specific Chatwoot version, use `-U`/`--Upgrade` with a git ref.
+### Upgrading to a specific version
+
+`cwctl` also supports experimental upgrades to a specific Chatwoot version. This is useful when an instance is several releases behind and needs to be upgraded through intermediate versions instead of jumping directly to the latest release.
 
 ```bash
-sudo cwctl -U <VERSION>
-# example
 sudo cwctl -U v4.3.0
 ```
 
-<Note>
-`-u`/`--upgrade` upgrades to latest stable (`master`), while `-U`/`--Upgrade` upgrades to a specific git ref and is currently experimental. Upgrades can fail when your Chatwoot repo has local code changes, so keep production changes clean and take backups before upgrading. Under the hood, `-U` performs a `git checkout <VERSION>` followed by `git pull`.
-</Note>
+<Warning>
+`-U`/`--Upgrade` is experimental and is not recommended for production environments without testing. When using a release tag like `v4.3.0`, Git may print a pull warning because tags are checked out in a detached HEAD state.
+</Warning>
+
+Before upgrading, take a backup, review the release notes for the target version, and keep the Chatwoot repository clean. The upgrade will abort if local code changes are detected.
 
 ### Setup Nginx with SSL after installation
 

--- a/self-hosted/deployment/chatwoot-ctl.mdx
+++ b/self-hosted/deployment/chatwoot-ctl.mdx
@@ -53,12 +53,16 @@ sudo cwctl --upgrade
 This will upgrade your Chatwoot instance to the latest stable release. If you are running a custom branch in production do not use this to upgrade.
 </Note>
 
-### Upgrading to a specific version
+### Upgrading to a specific version or branch
 
-`cwctl` also supports experimental upgrades to a specific Chatwoot version. This is useful when an instance is several releases behind and needs to be upgraded through intermediate versions instead of jumping directly to the latest release.
+`cwctl` also supports experimental upgrades to a specific Chatwoot version or branch. This is useful when an instance is several releases behind and needs to be upgraded through intermediate versions instead of jumping directly to the latest release. You can also use this to upgrade from a branch such as `develop`.
 
 ```bash
+# Upgrade to a specific released version
 sudo cwctl -U v4.3.0
+
+# Upgrade from a branch
+sudo cwctl -U develop
 ```
 
 <Warning>

--- a/self-hosted/deployment/docker.mdx
+++ b/self-hosted/deployment/docker.mdx
@@ -181,6 +181,10 @@ To set up the database for the first time, you must run `rails db:chatwoot_prepa
 
 If you're not using the `latest` or `latest-ce` tag, you first need to change the desired tag in your docker-compose file.
 
+<Note>
+If your installation is very old, upgrade iteratively through intermediate Docker image tags instead of jumping directly to the latest image. Review the release notes between versions and run `rails db:chatwoot_prepare` after each upgrade.
+</Note>
+
 After that you can pull the new image and start using them:
 
 ```bash

--- a/self-hosted/deployment/upgrade.mdx
+++ b/self-hosted/deployment/upgrade.mdx
@@ -20,6 +20,10 @@ If you are on an older version of Chatwoot(< 2.7), follow the [manual upgrade st
 cwctl --upgrade
 ```
 
+<Note>
+To reduce risk of breakages, upgrade iteratively across versions instead of skipping many releases in one jump (for example, avoid upgrading directly from `v4.1` to `v4.10`).
+</Note>
+
 This upgrade method is applicable for all manual linux installations including installation using aws marketplace.
 
 ## Docker

--- a/self-hosted/deployment/upgrade.mdx
+++ b/self-hosted/deployment/upgrade.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Upgrade
 Whenever a new version of Chatwoot is released, use the following steps to upgrade your instance.
 
 <Note>
-To install `cwctl`, refer [this](#install-or-upgrade-chatwoot-cli) section below.
+To install `cwctl`, refer to the [Chatwoot CTL guide](/self-hosted/deployment/chatwoot-ctl#install-or-upgrade-chatwoot-ctl).
 </Note>
 
 <Note>
@@ -17,18 +17,22 @@ If you are on an older version of Chatwoot(< 2.7), follow the [manual upgrade st
 </Note>
 
 ```bash
-cwctl --upgrade
+sudo cwctl --upgrade
 ```
 
 <Note>
-To reduce risk of breakages, upgrade iteratively across versions instead of skipping many releases in one jump (for example, avoid upgrading directly from `v4.1` to `v4.10`).
+Before upgrading, review the release notes for versions between your current installation and the target version. If your installation is very old, upgrade iteratively through intermediate versions instead of jumping directly to the latest release. This helps you apply required migrations and configuration changes in the expected order. Test the upgrade on a staging instance first.
 </Note>
 
-This upgrade method is applicable for all manual linux installations including installation using aws marketplace.
+This upgrade method is applicable for all manual Linux installations, including installations using AWS Marketplace.
 
 ## Docker
 
 Update the images using the latest image from chatwoot.
+
+<Note>
+If your installation is very old, upgrade iteratively through intermediate Docker image tags instead of jumping directly to the latest image. Review the release notes between versions, update the image tag in your Docker Compose file for each target version, and run the database preparation step after each upgrade.
+</Note>
 
 ```bash
 docker-compose down

--- a/self-hosted/deployment/upgrade.mdx
+++ b/self-hosted/deployment/upgrade.mdx
@@ -21,7 +21,7 @@ sudo cwctl --upgrade
 ```
 
 <Note>
-Before upgrading, review the release notes for versions between your current installation and the target version. If your installation is very old, upgrade iteratively through intermediate versions instead of jumping directly to the latest release. This helps you apply required migrations and configuration changes in the expected order. Test the upgrade on a staging instance first.
+Before upgrading, review the release notes for versions between your current installation and the target version. If your installation is very old, upgrade iteratively through intermediate versions instead of jumping directly to the latest release. This helps you apply required migrations and configuration changes in the expected order. Use the [specific version upgrade flow](/self-hosted/deployment/chatwoot-ctl#upgrading-to-a-specific-version-or-branch) when you need to stop at an intermediate Linux VM version, and test the upgrade on a staging instance first.
 </Note>
 
 This upgrade method is applicable for all manual Linux installations, including installations using AWS Marketplace.


### PR DESCRIPTION
## Summary

Clarifies specific-version upgrade guidance for Linux VM and Docker deployments.

## Why

Older Chatwoot installations may need to upgrade through intermediate versions instead of jumping directly to the latest release. This helps migrations and configuration changes run in the expected order.

## What this change does

- Documents `sudo cwctl --upgrade` as the standard Linux VM upgrade command
- Adds guidance for upgrading a Linux VM installation to a specific Chatwoot version with `sudo cwctl -U v4.3.0`
- Mentions that `-U` also supports branch upgrades, such as `sudo cwctl -U develop`
- Notes that release tags can print a Git pull warning because tags use detached HEAD
- Recommends backups, a clean Chatwoot repository, release-note review, and staging validation before Linux VM upgrades
- Adds Docker guidance to upgrade iteratively through intermediate image tags for very old installations
- Fixes the Chatwoot CTL install link and Linux/AWS Marketplace wording on the upgrade page

## Validation

- Cross-checked against `deployment/setup_20.04.sh` in the Chatwoot codebase
- Verified heredoc shell behavior for failed intermediate commands
- Ran `git diff --check`
