### PR TITLE
docs: complete the list of paths required for ChatWidget behind auth gateways

### DIFF
--- a/self-hosted/restricted-instances.mdx
+++ b/self-hosted/restricted-instances.mdx
@@ -37,13 +37,14 @@ This wildcard approach ensures all necessary widget functionalities such as conv
 
 ### Widget Assets
 
-Make sure that static assets required by the ChatWidget are accessible. These are typically served from:
+Make sure that all static assets required by the ChatWidget are accessible. The widget uses two asset paths:
 
 ```
 https://yourdomain.com/packs
+https://yourdomain.com/vite/assets
 ```
 
-Ensure all paths under this directory are accessible to support the widget fully.
+The `/packs` path serves the SDK loader script (`packs/js/sdk.js`) that is embedded into the parent page. The `/vite/assets` path serves the JavaScript and CSS bundles loaded inside the widget iframe (Chatwoot migrated this UI from Webpack to Vite). Both paths must be publicly accessible to support the widget fully.
 
 ### Widget Page
 

--- a/self-hosted/restricted-instances.mdx
+++ b/self-hosted/restricted-instances.mdx
@@ -45,6 +45,16 @@ https://yourdomain.com/packs
 
 Ensure all paths under this directory are accessible to support the widget fully.
 
+### Widget Page
+
+The Chatwoot SDK loads the chat UI by injecting an iframe whose `src` points to `/widget`. This path must also be publicly accessible for the widget to render:
+
+```
+https://yourdomain.com/widget
+```
+
+Without this, the SDK script loads correctly but the iframe fails to load, resulting in a missing chat bubble. This commonly affects deployments behind authentication gateways such as Cloudflare Access, basic auth, or other ZTNA proxies.
+
 ## SMTP Configuration for Emails
 
 Proper SMTP setup is essential for managing email communications within restricted networks:

--- a/self-hosted/restricted-instances.mdx
+++ b/self-hosted/restricted-instances.mdx
@@ -37,14 +37,21 @@ This wildcard approach ensures all necessary widget functionalities such as conv
 
 ### Widget Assets
 
-Make sure that all static assets required by the ChatWidget are accessible. The widget uses two asset paths:
+Make sure that all static and media assets the widget loads are accessible. The widget pulls from four paths:
 
 ```
 https://yourdomain.com/packs
 https://yourdomain.com/vite/assets
+https://yourdomain.com/brand-assets
+https://yourdomain.com/rails/active_storage
 ```
 
-The `/packs` path serves the SDK loader script (`packs/js/sdk.js`) that is embedded into the parent page. The `/vite/assets` path serves the JavaScript and CSS bundles loaded inside the widget iframe (Chatwoot migrated this UI from Webpack to Vite). Both paths must be publicly accessible to support the widget fully.
+- **`/packs`** — the SDK loader script (`packs/js/sdk.js`) embedded into the parent page.
+- **`/vite/assets`** — JavaScript and CSS bundles loaded inside the widget iframe. Chatwoot migrated this UI from Webpack to Vite, so older guides referring only to `/packs` are incomplete for newer deployments.
+- **`/brand-assets`** — installation-level branding (logo, favicon) shown inside the widget.
+- **`/rails/active_storage`** — image and file attachments. Used for both visitor uploads and any media the agent sends back. Without this, attachments display as broken images on the visitor side.
+
+All four paths must be publicly accessible to support the widget fully.
 
 ### Widget Page
 

--- a/self-hosted/restricted-instances.mdx
+++ b/self-hosted/restricted-instances.mdx
@@ -49,9 +49,11 @@ https://yourdomain.com/rails/active_storage
 - **`/packs`** — the SDK loader script (`packs/js/sdk.js`) embedded into the parent page.
 - **`/vite/assets`** — JavaScript and CSS bundles loaded inside the widget iframe. Chatwoot migrated this UI from Webpack to Vite, so older guides referring only to `/packs` are incomplete for newer deployments.
 - **`/brand-assets`** — installation-level branding (logo, favicon) shown inside the widget.
-- **`/rails/active_storage`** — image and file attachments. Used for both visitor uploads and any media the agent sends back. Without this, attachments display as broken images on the visitor side.
+- **`/rails/active_storage`** — stored image and file attachment URLs. Without this, attachments can display as broken images or inaccessible files in the widget.
 
 All four paths must be publicly accessible to support the widget fully.
+
+Visitor file uploads are handled through the widget API endpoints covered above. If you use an external storage service such as S3, GCS, Azure Storage, or another S3-compatible provider, Chatwoot still generates `/rails/active_storage/...` URLs first and then redirects the browser to the storage provider's signed URL. In that setup, make sure visitors can also reach the storage provider or CDN hostname.
 
 ### Widget Page
 
@@ -93,4 +95,4 @@ Implement comprehensive monitoring and logging solutions to swiftly detect and a
 
 <Note>
 By following these detailed instructions, your Chatwoot deployment can effectively operate within restricted network environments, ensuring a robust and secure customer support platform.
-</Note> 
+</Note>


### PR DESCRIPTION
## Summary

The **Enabling ChatWidget for Users** section in `restricted-instances.mdx` listed only three paths (`/cable`, `/api/v1/widget/*`, `/packs`). That is incomplete for self-hosted Chatwoot deployments behind auth gateways such as Cloudflare Access, basic auth, ZTNA, or an internal reverse proxy.

This PR documents the additional public paths the widget needs to render and load its assets reliably.

## Missing paths this documents

| Path | What it serves | Symptom when blocked |
| --- | --- | --- |
| `/widget` | The iframe HTML the SDK loads to render the chat UI | SDK script loads but no chat bubble appears |
| `/vite/assets` | JS / CSS bundles for the iframe in newer Chatwoot versions | Iframe HTML loads but renders blank |
| `/brand-assets` | Installation branding such as the widget footer logo | Broken branding image in the widget |
| `/rails/active_storage` | Stored attachment URLs served through Rails Active Storage | Images/files in widget conversations can appear broken or inaccessible |

## What this change does

- Adds a **Widget Page** subsection documenting `/widget` as a required public path.
- Expands **Widget Assets** to include `/packs`, `/vite/assets`, `/brand-assets`, and `/rails/active_storage`.
- Clarifies that visitor uploads use the existing `/api/v1/widget/*` API path, while stored attachment URLs use `/rails/active_storage/...`.
- Notes that external storage providers can redirect from `/rails/active_storage/...` to signed provider/CDN URLs, so visitors must also be able to reach that provider hostname.

## Validation

- Verified `/widget` against `config/routes.rb` and `app/javascript/sdk/IFrameHelper.js` in the Chatwoot app.
- Verified the widget iframe loads Vite assets through `app/views/widgets/show.html.erb`.
- Verified default branding assets under `/brand-assets` from installation config and widget branding code.
- Verified attachment display URLs use Rails Active Storage paths, while visitor uploads are handled by widget API endpoints.
- Ran `git diff --check`.